### PR TITLE
Improves today and week output

### DIFF
--- a/cmds/today.js
+++ b/cmds/today.js
@@ -39,12 +39,35 @@ exports.handler = async function (argv) {
         let project = projects.find(x=> x.id == p);
         report.push({
             project,
+            project_name: project.name,
             seconds: total,
             duration_formatted:  dayjs.duration(total*1000).format('H[h] m[m]'),
             duration:  dayjs.duration(total*1000).format('H:mm:ss')
         });
     })
-    console.log(JSON.stringify(report));
+    // TODO make format a CLI option
+    let format = 'table'; // csv | json | table defaults to table
+    displayDailyReport(report,format);
 
 
 }
+
+// TODO should this be moved to a formatter file?
+function displayDailyReport(report,format) {
+    switch (format) {
+        case 'csv':
+            // TODO maybe use jsontocsv
+            console.log(JSON.stringify(report));
+            break;
+        case 'json':
+            console.log(JSON.stringify(report));
+            break;
+        case 'table':
+        default:
+            console.table(report,['project_name','duration_formatted']);
+            break;
+    }
+    
+    
+}
+

--- a/cmds/weekly.js
+++ b/cmds/weekly.js
@@ -16,9 +16,27 @@ exports.handler = async function (argv) {
     weeklyReport = await client.reports.weekly(workspace.id,params);
     // displayReportText(weeklyReport.data);
     // displayReportJson(weeklyReport.data);
-    console.log(weeklyReport.data)
-    console.table(weeklyReport.data,['title','totals'])
+    // console.log(weeklyReport.data)
+    // console.table(weeklyReport.data,['title','totals'])
+    // console.log(JSON.stringify(weeklyReport));
 
+    let reportData = []
+    weeklyReport.data.map(project=>{
+        let row = {
+            projectId: project.pid,
+            projectName: project.title.project,
+        }
+        for (let i = 0; i < project.totals.length; i++) {
+            const element = project.totals[i];
+            let date = dayjs().startOf('week').add(i,'days').format('YYYY-MM-DD');
+            // dayjs.duration(stopped.duration*1000).format('H[h] m[m]');
+            // let duration = dayjs.duration(stopped.duration*1000).format('H[h] m[m]');
+            date = i==7 ? 'Total' : date;
+            row[date] = element; // TODO convert from milliseconds to duration
+        }
+        reportData.push(row);
+    })
+    console.table(reportData);
 }
 
 async function getWorkspace() {

--- a/cmds/weekly.js
+++ b/cmds/weekly.js
@@ -14,8 +14,11 @@ exports.handler = async function (argv) {
     let workspace = await getWorkspace();
     let params = { since: dayjs().startOf('week').toISOString() };
     weeklyReport = await client.reports.weekly(workspace.id,params);
-    displayReportText(weeklyReport.data);
+    // displayReportText(weeklyReport.data);
     // displayReportJson(weeklyReport.data);
+    console.log(weeklyReport.data)
+    console.table(weeklyReport.data,['title','totals'])
+
 }
 
 async function getWorkspace() {
@@ -24,6 +27,30 @@ async function getWorkspace() {
     return workspaces[0];
 }
 
+
+
+// We need to get the data shaped like
+// which happens to be very much like displayReportText() is doing
+// except its writing to the console instead of an object
+
+// {
+//     "Project 1": {
+//         "2022-01-01": 1100,
+//         "2022-01-02": 1100,
+//         "2022-01-03": 1100,
+//         "2022-01-04": 1100,
+//         "2022-01-05": 1100
+//     },
+//     "Worked": {
+//         "2022-01-01": 1100,
+//         "2022-01-02": 1100,
+//         "2022-01-03": 1100,
+//         "2022-01-04": 1100,
+//         "2022-01-05": 1100
+//     }
+// }
+
+// Then console.table() will work "nicely"
 
 function displayReportJson(data) {
     let json = []
@@ -44,6 +71,7 @@ function displayReportJson(data) {
         });
     });
     console.log(JSON.stringify(json));
+    console.table(json);
 } 
 
 function displayReportText(data) {

--- a/cmds/weekly.js
+++ b/cmds/weekly.js
@@ -1,7 +1,7 @@
 const Client = require('../client');
 const dayjs = require('dayjs');
 var dur = require('dayjs/plugin/duration')
-var relativeTime = require('dayjs/plugin/relativeTime')
+var relativeTime = require('dayjs/plugin/relativeTime');
 dayjs.extend(relativeTime)
 dayjs.extend(dur);
 
@@ -23,19 +23,33 @@ exports.handler = async function (argv) {
     let reportData = []
     weeklyReport.data.map(project=>{
         let row = {
-            projectId: project.pid,
             projectName: project.title.project,
+            projectId: project.pid
         }
         for (let i = 0; i < project.totals.length; i++) {
             const element = project.totals[i];
-            let date = dayjs().startOf('week').add(i,'days').format('YYYY-MM-DD');
-            // dayjs.duration(stopped.duration*1000).format('H[h] m[m]');
-            // let duration = dayjs.duration(stopped.duration*1000).format('H[h] m[m]');
+            let date = dayjs().startOf('week').add(i,'days').format('ddd MM-DD');
+            // TODO this should not be a magic number
             date = i==7 ? 'Total' : date;
-            row[date] = element; // TODO convert from milliseconds to duration
+            let duration = element ? element :0 ;
+            row[date] = dayjs.duration(duration).format('H[h] m[m]'); // TODO convert from milliseconds to duration
         }
         reportData.push(row);
     })
+    let totalRow = {
+        projectName: 'Total',
+        projectId: '',
+    }
+    weeklyReport.week_totals
+    for (let i = 0; i < weeklyReport.week_totals.length; i++) {
+        const element = weeklyReport.week_totals[i];
+        let date = dayjs().startOf('week').add(i,'days').format('ddd MM-DD');
+        // TODO this should not be a magic number
+        date = i==7 ? 'Total' : date;
+        let duration = element ? element :0 ;
+        totalRow[date] = dayjs.duration(duration).format('H[h] m[m]'); // TODO convert from milliseconds to duration
+    }
+    reportData.push(totalRow);
     console.table(reportData);
 }
 
@@ -47,29 +61,7 @@ async function getWorkspace() {
 
 
 
-// We need to get the data shaped like
-// which happens to be very much like displayReportText() is doing
-// except its writing to the console instead of an object
-
-// {
-//     "Project 1": {
-//         "2022-01-01": 1100,
-//         "2022-01-02": 1100,
-//         "2022-01-03": 1100,
-//         "2022-01-04": 1100,
-//         "2022-01-05": 1100
-//     },
-//     "Worked": {
-//         "2022-01-01": 1100,
-//         "2022-01-02": 1100,
-//         "2022-01-03": 1100,
-//         "2022-01-04": 1100,
-//         "2022-01-05": 1100
-//     }
-// }
-
-// Then console.table() will work "nicely"
-
+// TODO figure out what to do with these
 function displayReportJson(data) {
     let json = []
     data.map(project => {
@@ -92,6 +84,7 @@ function displayReportJson(data) {
     console.table(json);
 } 
 
+// TODO figure out what do to with these
 function displayReportText(data) {
     data.map(project => {
         console.info(project.title.project);

--- a/cmds/weekly.js
+++ b/cmds/weekly.js
@@ -37,7 +37,8 @@ function displayReportJson(data) {
             let entry = {
                 project: project.title.project,
                 date: day,
-                duration: duration
+                duration: duration,
+                total: total
             }
             json.push(entry);
         });
@@ -51,7 +52,10 @@ function displayReportText(data) {
         let startOfWeek = dayjs().startOf('week');
         project.totals.map((total, i) => {
             // TODO see https://runkit.com/6022b36c23da0600130851a0/6022b36c7614ed001ad11853 for formatting options
-            let duration = dayjs.duration(total, 'milliseconds').format('H[h] m[m]');
+            var dur = dayjs.duration(total, 'milliseconds');
+            var hours = (dur.days() * 24) + dur.hours()
+            let duration = `${hours}h ${dur.minutes()}m `
+            // let duration = `${hours}h ${dur.minutes()}m ${dur.seconds()}s`
             let day = startOfWeek.add(i, 'days').format('ddd MMM D');
             i == 7 ? console.info(`\tTotal : ${duration}`) : console.info(`\t ${day} - ${duration}`);
         });


### PR DESCRIPTION
The today and week commands will output a table (an ugly `console.table`, but it is still a table).

I've started to figure out how to format the time better, but the usage is inconsistent. This will be addressed in a subsequent PR