### PR TITLE
Continue with no match will now not start an unknown timentry

### DIFF
--- a/cmds/continue.js
+++ b/cmds/continue.js
@@ -32,11 +32,14 @@ exports.handler = async function (argv) {
         billable: matchingTimeEntry?.billable,
         dur: matchingTimeEntry?.dur
     }
-
-    let timeEntry = await utils.createTimeEntry(params);
-    let project = await utils.getProjectById(timeEntry.wid,timeEntry.pid)
-    console.info(`Continued ${timeEntry?.description} for project ${project?.name}`);
-
+    
+    if (matchingTimeEntry != {}) {
+        let timeEntry = await utils.createTimeEntry(params);
+        let project = await utils.getProjectById(timeEntry.wid,timeEntry.pid)
+        console.info(`Continued ${timeEntry?.description} for project ${project?.name}`);
+    } else {
+        console.info('No matching time entry found!');
+    }
 
 }
 

--- a/cmds/continue.js
+++ b/cmds/continue.js
@@ -21,10 +21,10 @@ exports.handler = async function (argv) {
             break;
         default:
             let searchName = argv.description.toLowerCase();
-            matchingTimeEntry = timeEntries.find(x=>x.description.toLowerCase().includes(searchName)) || {};
+            matchingTimeEntry = timeEntries.find(x=>x.description.toLowerCase().includes(searchName));
             break;
     }
-    
+
     let params = {
         projectId: matchingTimeEntry?.pid,
         workspaceId: matchingTimeEntry?.wid,
@@ -33,7 +33,7 @@ exports.handler = async function (argv) {
         dur: matchingTimeEntry?.dur
     }
     
-    if (matchingTimeEntry != {}) {
+    if (matchingTimeEntry ) {
         let timeEntry = await utils.createTimeEntry(params);
         let project = await utils.getProjectById(timeEntry.wid,timeEntry.pid)
         console.info(`Continued ${timeEntry?.description} for project ${project?.name}`);


### PR DESCRIPTION
Resolves the issue where `continue` with a search term that doesn't match was starting an undefined time entry. now it will error out with `No matching time entry found!`

Fixes #5 