### PR TITLE
feat: Add options for web command

### DIFF
--- a/cmds/web.mjs
+++ b/cmds/web.mjs
@@ -1,11 +1,23 @@
 import open from 'open'
 
 export const command = 'web'
-export const desc = 'Opens toggl track website with default browser'
-export const builder = {}
+export const desc = 'Opens toggl track website with default browser, defaults to the timer page'
+export const builder = {
+  t: { alias: ['timer'], describe: 'opens the timer page ', requiresArg: false },
+  r: { alias: ['reports'], describe: 'opens the reports page ', requiresArg: false  },
+
+}
 
 export const handler = async function (argv) {
-  const timerUrl = 'https://track.toggl.com/timer'
-  console.log(`Opening ${timerUrl}`)
-  open(timerUrl)
+  let baseUrl = 'https://track.toggl.com'
+  let pageUrl
+  if ( argv.timer) {
+    pageUrl = 'timer' 
+  } else if ( argv.reports) {
+    pageUrl = 'reports' 
+  } else {
+    pageUrl = 'timer'
+  }
+  console.log(`Opening ${baseUrl}/${pageUrl}`)
+  open(`${baseUrl}/${pageUrl}`)
 }


### PR DESCRIPTION
```
toggl web

Opens toggl track website with default browser, defaults to the timer page

Options:
      --version  Show version number                                   [boolean]
      --help     Show help                                             [boolean]
  -t, --timer    opens the timer page
  -r, --reports  opens the reports page
```

Fixes #28