### PR TITLE
fix: converts project id, workspace id to number

### DIFF
--- a/standalone/startTimeEntry.js
+++ b/standalone/startTimeEntry.js
@@ -22,7 +22,7 @@ async function main () {
   const params = { description }
   params.workspaceId = options.workspaceId || defaultWorkspaceId
   params.projectId = options.projectId || defaultProjectId
-  console.debug(params)
+  // console.debug(params)
   const timeEntry = await createTimeEntry(params)
   console.info(`Started ${timeEntry.description} with project id ${timeEntry.pid}`)
 }
@@ -32,8 +32,8 @@ async function createTimeEntry (params) {
   const timeEntry = await client.timeEntries.create(
     {
       description: params.description,
-      wid: params.workspaceId,
-      pid: params.projectId,
+      workspace_id: +params.workspaceId,
+      project_id: +params.projectId,
       start: dayjs().toISOString(),
       duration: -1 * dayjs().unix(),
       created_with: 'My app',

--- a/utils.js
+++ b/utils.js
@@ -44,8 +44,8 @@ export const createTimeEntry = async function (params) {
   const timeEntry = await client.timeEntries.create(
     {
       description: params.description,
-      workspace_id: params.workspaceId,
-      project_id: params.projectId,
+      workspace_id: +params.workspaceId,
+      project_id: +params.projectId,
       start: dayjs().toISOString(),
       duration: -1 * dayjs().unix(),
       created_with: appName,


### PR DESCRIPTION
Fixes the issue where you cannot start a new time entry, because the workspace id and project id were being passed in as strings, not numbers.

Fixes #38