### PR TITLE
fix: makes weekly report work in v9 API

### DIFF
--- a/cmds/weekly.mjs
+++ b/cmds/weekly.mjs
@@ -33,7 +33,7 @@ export const handler = async function (argv) {
       const duration = element || 0
       row[date] = formatDuration(duration * 1000)
       totals[i] += duration // for use with a daily total row
-      row['Total'] += duration // accumulate the projects weekly totoal
+      row.Total += duration // accumulate the projects weekly totoal
     }
     reportData.push(row)
   }
@@ -47,14 +47,13 @@ export const handler = async function (argv) {
     const seconds = totals[i]
     const date = dayjs().startOf('week').add(i, 'days').format('ddd MM-DD')
     totalRow[date] = formatDuration(seconds * 1000)
-    totalRow['Total'] += seconds // accumulate the projects weekly totoal
-
+    totalRow.Total += seconds // accumulate the projects weekly totoal
   }
   reportData.push(totalRow)
 
-  // TODO formatDuration on the `Total` property
-  console.log(reportData)
-  // TODO update the order so total is at the end - an alternative would be to build the dates up front
+  for (const project of reportData) {
+    project.Total = formatDuration(project.Total * 1000)
+  }
   console.table(reportData)
 }
 

--- a/cmds/weekly.mjs
+++ b/cmds/weekly.mjs
@@ -16,7 +16,7 @@ export const handler = async function (argv) {
   const workspace = await getWorkspace()
 
   const params = { } // Leave this for future options, like rounding
-  const weeklyReport = await client.reports.weekly(workspace.id,params)
+  const weeklyReport = await client.reports.weekly(workspace.id, params)
 
   const reportData = []
   const totals = [0, 0, 0, 0, 0, 0, 0] // ? Is there a better way to do this?

--- a/cmds/weekly.mjs
+++ b/cmds/weekly.mjs
@@ -8,7 +8,7 @@ dayjs.extend(dur)
 
 export const command = 'week'
 // FIXME descriptions
-export const desc = 'NOT WORKING in V9 Weekly project summary by day'
+export const desc = 'Weekly project summary by day'
 export const builder = {}
 
 export const handler = async function (argv) {

--- a/cmds/weekly.mjs
+++ b/cmds/weekly.mjs
@@ -23,7 +23,8 @@ export const handler = async function (argv) {
   for (const project of weeklyReport) {
     const currentProject = await getProjectById(workspace.id, project.project_id)
     const row = {
-      projectName: currentProject.name
+      projectName: currentProject.name,
+      Total: 0
     }
 
     for (let i = 0; i < project.seconds.length; i++) {
@@ -31,21 +32,29 @@ export const handler = async function (argv) {
       const date = dayjs().startOf('week').add(i, 'days').format('ddd MM-DD')
       const duration = element || 0
       row[date] = formatDuration(duration * 1000)
-      totals[i] += duration
+      totals[i] += duration // for use with a daily total row
+      row['Total'] += duration // accumulate the projects weekly totoal
     }
     reportData.push(row)
   }
 
   const totalRow = {
-    projectName: 'Total'
+    projectName: 'Total',
+    Total: 0
   }
 
   for (let i = 0; i < totals.length; i++) {
     const seconds = totals[i]
     const date = dayjs().startOf('week').add(i, 'days').format('ddd MM-DD')
     totalRow[date] = formatDuration(seconds * 1000)
+    totalRow['Total'] += seconds // accumulate the projects weekly totoal
+
   }
   reportData.push(totalRow)
+
+  // TODO formatDuration on the `Total` property
+  console.log(reportData)
+  // TODO update the order so total is at the end - an alternative would be to build the dates up front
   console.table(reportData)
 }
 

--- a/cmds/weekly.mjs
+++ b/cmds/weekly.mjs
@@ -1,5 +1,5 @@
 import Client from '../client.js'
-import { getWorkspace, formatDuration } from '../utils.js'
+import { getWorkspace, formatDuration, getProjectById } from '../utils.js'
 import dayjs from 'dayjs'
 import dur from 'dayjs/plugin/duration.js'
 import relativeTime from 'dayjs/plugin/relativeTime.js'
@@ -14,6 +14,7 @@ export const builder = {}
 export const handler = async function (argv) {
   const client = Client()
   const workspace = await getWorkspace()
+  // TODO check the date range because the dates aren't lining up properly
   // TODO THis should be filtered after the fact, because weekly will only provide a single week's data
   const params = { since: dayjs().startOf('week').toISOString() }
   const weeklyReport = await client.reports.weekly(workspace.id, params)
@@ -36,20 +37,19 @@ export const handler = async function (argv) {
   //     ]
   //   },
   // ]
-  console.log(weeklyReport)
+  // console.log(weeklyReport)
   for (const project of weeklyReport) {
+    const currentProject = await getProjectById(workspace.id,project.project_id)
     const row = {
-      projectName: project.project_id // FIXME look up project name
-      // projectId: project.pid
+      projectName: currentProject.name 
     }
     // TODO compute each days time total
-    // for (let i = 0; i < project.totals.length; i++) {
-    //   const element = project.totals[i]
-    //   let date = dayjs().startOf('week').add(i, 'days').format('ddd MM-DD')
-    //   date = i == weeklyReport.week_totals.length - 1 ? 'Total' : date
-    //   const duration = element || 0
-    //   row[date] = formatDuration(duration)
-    // }
+    for (let i = 0; i < project.seconds.length; i++) {
+      const element = project.seconds[i]
+      let date = dayjs().startOf('week').add(i, 'days').format('ddd MM-DD')
+      const duration = element || 0
+      row[date] = formatDuration(duration*1000)
+    }
     reportData.push(row)
   }
   const totalRow = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "dayjs": "^1.11.6",
         "dotenv": "^16.0.3",
         "open": "^8.4.0",
-        "toggl-client": "^3.0.0",
+        "toggl-client": "^3.1.1",
         "yargs": "^17.6.0"
       },
       "bin": {
@@ -7254,13 +7254,13 @@
       }
     },
     "node_modules/toggl-client": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/toggl-client/-/toggl-client-3.1.0.tgz",
-      "integrity": "sha512-/AYmsw+amAs4L/6duuxGNPmR1cVog9avGKu8zmA2CIF7cKRrriYQwRWw7yeY5farjHvnIXNZCNJUeesK+wqfEA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/toggl-client/-/toggl-client-3.1.1.tgz",
+      "integrity": "sha512-0ELL3luV5n3Wv4Ir8qoAcBkSJ6yG7jlZIBoNuq3YolGAdTR6KfUTotAwsqk7ZNb1M6NChBEKRdWna7hq43ubaw==",
       "dependencies": {
         "dayjs": "^1.11.7",
         "debug": "^4.3.4",
-        "got": "^12.0.4"
+        "got": "^12.5.3"
       }
     },
     "node_modules/trim-newlines": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "dayjs": "^1.11.6",
     "dotenv": "^16.0.3",
     "open": "^8.4.0",
-    "toggl-client": "^3.0.0",
+    "toggl-client": "^3.1.1",
     "yargs": "^17.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates the weekly report, properly translating the new API response to display the table for the week.

Depends on https://github.com/saintedlama/toggl-client/pull/48 

Fixes #35
