### PR TITLE
Still cannot edit time entries

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,5 +12,6 @@
         "sourceType": "module"
     },
     "rules": {
+        "allowTernary": true 
     }
 }

--- a/cmds/edit.mjs
+++ b/cmds/edit.mjs
@@ -59,8 +59,8 @@ export const handler = async function (argv) {
   project ? params.project_id = +project.id : undefined
   startTime ? params.start = startTime.toISOString() : undefined
   endTime ? params.stop = endTime.toISOString() : undefined
-  endTime ? params.duration = endTime.diff(startTime, 'seconds') : undefined
   argv.description ? params.description = argv.description : undefined
+  debug(params)
   const timeEntry = await client.timeEntries.update(currentTimeEntry.id, params)
   await displayTimeEntry(timeEntry)
 }

--- a/cmds/edit.mjs
+++ b/cmds/edit.mjs
@@ -9,13 +9,14 @@ dayjs.extend(timezone)
 
 export const command = 'edit'
 // FIXME editing not working
-export const desc = 'SOMETHING IS NOT RIGHT Edits the current running time entry'
+export const desc = `Edits the current running time entry. Only updating the time is supported `+
+`and the time must be parsable by dayjs, e.g. 4:50PM or '12:00 AM'.`
 
 export const builder = {
   d: { alias: ['description'], describe: 'Time entry name', type: 'string:' },
   p: { alias: ['projectId', 'project'], describe: 'The case insensitive project name or project id.', type: 'string', demandOption: false },
-  s: { alias: ['start', 'startTime'], describe: 'The case insensitive project name or project id.', type: 'string', demandOption: false },
-  e: { alias: ['end', 'endTime'], describe: 'The case insensitive project name or project id.', type: 'string', demandOption: false }
+  s: { alias: ['start', 'startTime'], describe: 'The start time for the task, e.g. 13:00 12:45AM.', type: 'string', demandOption: false },
+  e: { alias: ['end', 'endTime'], describe: 'The end time for the task, e.g. 13:00 12:45AM.', type: 'string', demandOption: false }
 }
 
 export const handler = async function (argv) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "dayjs": "^1.11.6",
+        "debug": "^4.3.4",
         "dotenv": "^16.0.3",
         "open": "^8.4.0",
         "toggl-client": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "license": "MIT",
   "dependencies": {
     "dayjs": "^1.11.6",
+    "debug": "^4.3.4",
     "dotenv": "^16.0.3",
     "open": "^8.4.0",
     "toggl-client": "^3.1.1",

--- a/utils.js
+++ b/utils.js
@@ -93,7 +93,7 @@ export const convertUtcTime = function (dateTime) {
   return dayjs(dateTime).tz(tz).format('YYYY-MM-DD HH:mm')
 }
 
-export const appName = 'toggl-cli-node'
+export const appName = '@beauraines/toggl-cli'
 
 /**
  * Displays a time entry on the console


### PR DESCRIPTION
- Adds debug
- Updates linter to allow ternary expressions without assignment
- feat: updates app name sent with API requests
- fix: can edit time entries
- docs(edit): updates the help command for edit

Fixes #43
