### PR TITLE
fix(weekly report): handles entries without project

### DIFF
--- a/cmds/currentTimeEntry.mjs
+++ b/cmds/currentTimeEntry.mjs
@@ -1,5 +1,8 @@
 import Client from '../client.js'
 import { displayTimeEntry } from '../utils.js'
+import debugClient from 'debug';
+
+const debug = debugClient('toggl-cli-now');
 
 export const command = 'now'
 export const desc = 'Displays the current running time entry'
@@ -9,6 +12,7 @@ export const handler = async function (argv) {
   const client = new Client()
   const currentTimeEntry = await client.timeEntries.current()
   if (currentTimeEntry) {
+    debug(currentTimeEntry)
     await displayTimeEntry(currentTimeEntry)
   } else {
     console.log('There is no time entry running!')

--- a/cmds/edit.mjs
+++ b/cmds/edit.mjs
@@ -9,7 +9,7 @@ import yargs from 'yargs'
 dayjs.extend(utc)
 dayjs.extend(timezone)
 
-const debug = debugClient('rtm-cli-edit');
+const debug = debugClient('toggl-cli-edit');
 
 export const command = 'edit'
 // FIXME editing not working

--- a/cmds/weekly.mjs
+++ b/cmds/weekly.mjs
@@ -2,11 +2,15 @@ import Client from '../client.js'
 import chalk from 'chalk'
 import { getWorkspace, formatDuration, getProjectById } from '../utils.js'
 import dayjs from 'dayjs'
+import debugClient from 'debug';
 import dur from 'dayjs/plugin/duration.js'
 import relativeTime from 'dayjs/plugin/relativeTime.js'
 import Table from 'cli-table3'
 dayjs.extend(relativeTime)
 dayjs.extend(dur)
+
+const debug = debugClient('toggl-cli-week');
+
 
 export const command = 'week'
 // FIXME descriptions
@@ -19,13 +23,14 @@ export const handler = async function (argv) {
 
   const params = { } // Leave this for future options, like rounding
   const weeklyReport = await client.reports.weekly(workspace.id, params)
-
+  debug(weeklyReport)
   const reportData = []
   const totals = [0, 0, 0, 0, 0, 0, 0] // ? Is there a better way to do this?
   for (const project of weeklyReport) {
     const currentProject = await getProjectById(workspace.id, project.project_id)
+    debug(currentProject)
     const row = {
-      projectName: currentProject.name,
+      projectName: currentProject ? currentProject.name : 'No Project',
       Total: 0
     }
 


### PR DESCRIPTION
The weekly report was failing when there were  time entries without a project. The CLI will always set a project based upon the default project, but the website or the chrome plugin don't always set the project.

Adds debug support for

- `toggl-cli-now`
- `toggl-cli-edit`
- `toggl-cli-week`

Fixes #63
