### PR TITLE
fix duration and date display in current running entries

### DIFF
--- a/cmds/ls.mjs
+++ b/cmds/ls.mjs
@@ -10,13 +10,14 @@ export const command = 'ls [searchStrings...]'
 export const desc = 'Lists recent time entries. Defaults to the last 14 days.'
 
 export const builder = {
-  d: { alias: ['days'], describe: 'The number of days to return.', type: 'number', demandOption: false, default: 14 }
+  d: { alias: ['days'], describe: 'The number of days to return. Ignored if --today provided', type: 'number', demandOption: false, default: 14 },
+  today: {describe: 'Only returns today\'s time entries. Overrides --days.', type: 'boolean', demandOption: false}
 }
 
 export const handler = async function (argv) {
   debug(argv)
   const client = Client()
-  const days = argv.days
+  const days = argv.today ? 0 : argv.days
   let timeEntries = await client.timeEntries.list({
     start_date: dayjs().subtract(days, 'days').startOf('day').toISOString(),
     end_date: dayjs().toISOString()
@@ -36,7 +37,6 @@ export const handler = async function (argv) {
 
   const report = []
   timeEntries.forEach(element => {
-    console.log(element)
     report.push(
       {
         description: element.description,

--- a/utils.js
+++ b/utils.js
@@ -121,7 +121,7 @@ export const displayTimeEntry = async function (timeEntry) {
 
     const tz = process.env.TOGGL_TIMEZONE || 'America/New_York'
     const startTimeFormatted = dayjs(timeEntry.start).tz(tz).format('YYYY-MM-DD HH:mm')
-    const stopTimeFormatted = dayjs(timeEntry.stop).tz(tz).format('YYYY-MM-DD HH:mm')
+    const stopTimeFormatted = timeEntry.stop ? dayjs(timeEntry.stop).tz(tz).format('YYYY-MM-DD HH:mm') : 'Currently Running'
 
     console.info(`Start: ${startTimeFormatted}`)
     console.info(`Stop: ${stopTimeFormatted}`) // This will always be blank for the current entry, but will be useful for a time entry


### PR DESCRIPTION
- Better formats null time (running entry) in displayTimeEntry, displaying `Currently Running` rather than `Invalid Date`
- Adds option to the `ls` command to only display today's entries
- Properly updates a time entries duration when editing a running entry
