### PR TITLE
fix: Improves handling of time entries with out a description

### DIFF
--- a/cmds/ls.mjs
+++ b/cmds/ls.mjs
@@ -39,7 +39,7 @@ export const handler = async function (argv) {
   timeEntries.forEach(element => {
     report.push(
       {
-        description: element.description,
+        description: element.description ? element.description : 'no description',
         project: projects.filter(p => p.id == element.project_id)[0]?.name,
         project_id: projects.filter(p => p.id == element.project_id)[0]?.id,
         start: convertUtcTime(element.start),

--- a/cmds/stopTimeEntry.mjs
+++ b/cmds/stopTimeEntry.mjs
@@ -11,7 +11,7 @@ export const handler = async function (argv) {
   if (currentTimeEntry) {
     const stopped = await client.timeEntries.stop(currentTimeEntry)
     const duration = dayjs.duration(stopped.duration * 1000).format('H[h] m[m]')
-    console.log(`Stopped ${stopped.description} after ${duration}`)
+    console.log(`Stopped ${stopped.description ? stopped.description : `time entry with no description`} after ${duration}`)
   } else {
     console.log('There is no time entry running!')
   }

--- a/utils.js
+++ b/utils.js
@@ -110,7 +110,7 @@ export const displayTimeEntry = async function (timeEntry) {
   if (!timeEntry) {
     console.log('There is no time entry running!')
   } else {
-    console.info(`${chalk.blueBright(timeEntry.description)} ${chalk.yellow('#'+timeEntry.id)}`)
+    console.info(`${chalk.blueBright(timeEntry.description ? timeEntry.description : 'no description')} ${chalk.yellow('#'+timeEntry.id)}`)
     console.info(`Billable: ${chalk.gray(timeEntry.billable)}`)
 
     // TODO this should be abstracted for reuse


### PR DESCRIPTION
Adds no description handling to the `now`, `ls` and `stop` commands.

Fixes #135
