### PR TITLE
fix(weekly report): fixes weekly report heading when there is no data

### DIFF
--- a/cmds/weekly.mjs
+++ b/cmds/weekly.mjs
@@ -54,7 +54,7 @@ export const handler = async function (argv) {
   }
 
   const totalRow = {
-    projectName: 'Total',
+    "Project Name": 'Total',
     Total: 0
   }
 


### PR DESCRIPTION
Fixes a second scenario where the weekly report had `projectName` and its more readable as `Project Name`
