### PR TITLE
chore: auto assign PRs to me

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,8 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: false
+
+reviewers: beauraines
+assign-yourself: false

--- a/.github/workflows/auto-assign-PR.yml
+++ b/.github/workflows/auto-assign-PR.yml
@@ -1,0 +1,14 @@
+name: Auto-assign reviewers for Dependabot PRs
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  assign-reviewers:
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign reviewers
+        uses: kentaro-m/auto-assign-action@v2.0.0
+


### PR DESCRIPTION
Uses kentaro-m/auto-assign-action@v2.0.0 to automatically set me as a reviewer for dependabot PRs I figure thats a little less invasive than assigned. Though its probably just the same