### PR TITLE
Add strict yargs

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -7,6 +7,7 @@ import { commands } from './cmds/index.mjs'
 yargs(hideBin(process.argv))
   .scriptName('toggl')
   .command(commands)
+  .strict()
   .completion('completion', 'Outputs bash/zsh-completion shortcuts for commands and options to add to .bashrc or .bash_profile')
   .demandCommand()
   .help()


### PR DESCRIPTION
Currently, running a command that doesn't exist has no indication of failure. This outputs help text if the command isn't registered