### PR TITLE
feat: short alias for description on start command

### DIFF
--- a/cmds/startTimeEntry.mjs
+++ b/cmds/startTimeEntry.mjs
@@ -5,7 +5,8 @@ export const command = 'start'
 export const desc = 'Starts a time entry'
 
 export const builder = {
-  description: {
+  d: {
+    alias: ['description'],
     describe: 'Time entry name',
     type: 'string:'
   },


### PR DESCRIPTION
Adds a short `-d` to set the description on the start command.

Resolves 193
